### PR TITLE
test.sh script for OSX - with reset feature

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -16,6 +16,7 @@ Request : "windows" Arduino IDE 1.6.x
 3. execute test.bat
 4. play it
 
+on OSX - edit test.sh and verify path to the arduino toolkit and path to the serial port device (it will show up as a file in /dev upon connectino and powerup of the arduboy)
 
 ## Controls
 dir : move

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export avrdudeconf=/Applications/Arduino.app/Contents/Java/hardware/tools/avr/etc/avrdude.conf
+export uart=/dev/tty.usbmodem1421
+export hexfile=test_arduboy_10.hex
+
+avrdude -C${avrdudeconf} -v -patmega32u4 -cavr109 -P${uart} -b57600 -D -Uflash:w:${hexfile}:i

--- a/test.sh
+++ b/test.sh
@@ -4,4 +4,6 @@ export avrdudeconf=/Applications/Arduino.app/Contents/Java/hardware/tools/avr/et
 export uart=/dev/tty.usbmodem1421
 export hexfile=test_arduboy_10.hex
 
+python -c "import serial;ser=serial.Serial('/dev/tty.usbmodem1421',1200);ser.write('');ser.close()"
+sleep 2
 avrdude -C${avrdudeconf} -v -patmega32u4 -cavr109 -P${uart} -b57600 -D -Uflash:w:${hexfile}:i


### PR DESCRIPTION
Hi, I added a quick and easy reset feature - simple oneliner in python that resets the device over serial port.
FYI - all it takes is to open the serial port at a 1200bps rate and 'ping it' - this triggers the bootloader.
